### PR TITLE
RelayNodeHash, RelayNodeEqual

### DIFF
--- a/include/tvm/relay/analysis.h
+++ b/include/tvm/relay/analysis.h
@@ -243,7 +243,7 @@ TVM_DLL Array<Pattern> UnmatchedCases(const Match& match, const IRModule& mod);
  *
  * \return The reference count mapping.
  */
-TVM_DLL std::unordered_map<const Object*, size_t> GetExprRefCount(const Expr& body);
+TVM_DLL std::unordered_map<const Expr, size_t, RelayNodeHash, RelayNodeEqual> GetExprRefCount(const Expr& body);
 
 /*!
  * \brief For each variable, count the number of times it appears in the Expr.

--- a/include/tvm/relay/expr.h
+++ b/include/tvm/relay/expr.h
@@ -656,16 +656,12 @@ inline size_t RelayNodeHash::operator()(const Expr& a) const {
 inline bool RelayNodeEqual::operator()(const Expr& a, const Expr& b) const {
   Expr left = a;
   Expr right = b;
-  if (const auto* var_node = a.as<VarNode>()) {
-    left = GetRef<Expr>(var_node->vid.as<IdNode>());
+  if (const auto* va = a.as<VarNode>()) {
+    if (const auto* vb = b.as<VarNode>()) {
+      return va->vid.same_as(vb->vid);
+   }
   }
-  if (const auto* var_node = b.as<VarNode>()) {
-    right = GetRef<Expr>(var_node->vid.as<IdNode>());
-  }
-  if (left.same_as(right)) {
-    return true;
-  }
-  return false;
+  return ObjectEqual()(a, b);
 }
 
 }  // namespace relay

--- a/include/tvm/relay/expr_functor.h
+++ b/include/tvm/relay/expr_functor.h
@@ -168,7 +168,7 @@ class ExprVisitor : public ::tvm::relay::ExprFunctor<void(const Expr& n)> {
 
  protected:
   // Internal visiting counter
-  std::unordered_map<const Object*, size_t> visit_counter_;
+  std::unordered_map<const Expr, size_t, RelayNodeHash, RelayNodeEqual> visit_counter_;
 };
 
 /*!
@@ -215,7 +215,7 @@ class ExprMutator : public ::tvm::relay::ExprFunctor<Expr(const Expr&)> {
 
  protected:
   /*! \brief Internal map used for memoization. */
-  std::unordered_map<Expr, Expr, ObjectPtrHash, ObjectPtrEqual> memo_;
+  std::unordered_map<Expr, Expr, RelayNodeHash, RelayNodeEqual> memo_;
 };
 
 /*!

--- a/include/tvm/runtime/object.h
+++ b/include/tvm/runtime/object.h
@@ -842,8 +842,9 @@ inline const ObjectType* ObjectRef::as() const {
 
 template <typename RefType, typename ObjType>
 inline RefType GetRef(const ObjType* ptr) {
-  static_assert(std::is_base_of<typename RefType::ContainerType, ObjType>::value,
-                "Can only cast to the ref of same container type");
+  
+  //static_assert(std::is_base_of<typename RefType::ContainerType, ObjType>::value,
+  //              "Can only cast to the ref of same container type");
   if (!RefType::_type_is_nullable) {
     CHECK(ptr != nullptr);
   }

--- a/include/tvm/runtime/object.h
+++ b/include/tvm/runtime/object.h
@@ -843,8 +843,8 @@ inline const ObjectType* ObjectRef::as() const {
 template <typename RefType, typename ObjType>
 inline RefType GetRef(const ObjType* ptr) {
   
-  //static_assert(std::is_base_of<typename RefType::ContainerType, ObjType>::value,
-  //              "Can only cast to the ref of same container type");
+  static_assert(std::is_base_of<typename RefType::ContainerType, ObjType>::value,
+                "Can only cast to the ref of same container type");
   if (!RefType::_type_is_nullable) {
     CHECK(ptr != nullptr);
   }

--- a/src/relay/analysis/util.cc
+++ b/src/relay/analysis/util.cc
@@ -364,10 +364,10 @@ TVM_REGISTER_GLOBAL("relay.analysis.all_dtypes").set_body_typed(AllDtypes);
  * \param body The body expression.
  * \return The reference count mapping.
  */
-std::unordered_map<const Object*, size_t> GetExprRefCount(const Expr& body) {
+std::unordered_map<const Expr, size_t, RelayNodeHash, RelayNodeEqual> GetExprRefCount(const Expr& body) {
   class ExprRefCounter : private MixedModeVisitor {
    public:
-    std::unordered_map<const Object*, size_t> Get(const Expr& body) {
+    std::unordered_map<const Expr, size_t, RelayNodeHash, RelayNodeEqual> Get(const Expr& body) {
       this->VisitExpr(body);
       return std::move(this->visit_counter_);
     }

--- a/src/relay/backend/graph_runtime_codegen.cc
+++ b/src/relay/backend/graph_runtime_codegen.cc
@@ -305,7 +305,7 @@ class GraphRuntimeCodegen : public backend::MemoizedExprTranslator<std::vector<G
 
   std::vector<GraphNodeRef> VisitExpr_(const VarNode* op) override {
     Expr expr = GetRef<Expr>(op);
-    return var_map_[expr.get()];
+    return var_map_[expr];
   }
 
   std::vector<GraphNodeRef> VisitExpr_(const ConstantNode* op) override {

--- a/src/relay/backend/graph_runtime_codegen.cc
+++ b/src/relay/backend/graph_runtime_codegen.cc
@@ -195,7 +195,7 @@ class GraphRuntimeCodegen : public backend::MemoizedExprTranslator<std::vector<G
     // First we convert all the parameters into input nodes.
     for (auto param : func->params) {
       auto node_ptr = GraphInputNode::make_node_ptr(param->name_hint(), GraphAttrs());
-      var_map_[param.get()] = AddNode(node_ptr, param);
+      var_map_[param] = AddNode(node_ptr, param);
     }
     heads_ = VisitExpr(func->body);
     std::ostringstream os;
@@ -410,8 +410,8 @@ class GraphRuntimeCodegen : public backend::MemoizedExprTranslator<std::vector<G
   }
 
   std::vector<GraphNodeRef> VisitExpr_(const LetNode* op) override {
-    CHECK_EQ(var_map_.count(op->var.get()), 0);
-    var_map_[op->var.get()] = VisitExpr(op->value);
+    CHECK_EQ(var_map_.count(op->var), 0);
+    var_map_[op->var] = VisitExpr(op->value);
     return VisitExpr(op->body);
   }
   std::vector<GraphNodeRef> VisitExpr_(const TupleGetItemNode* op) override {
@@ -535,7 +535,7 @@ class GraphRuntimeCodegen : public backend::MemoizedExprTranslator<std::vector<G
   /*! \brief mod */
   runtime::Module* mod_;
   /*! \brief variable map */
-  std::unordered_map<const Object*, std::vector<GraphNodeRef>> var_map_;
+  std::unordered_map<const Expr, std::vector<GraphNodeRef>, RelayNodeHash, RelayNodeEqual> var_map_;
   /*! \brief target device */
   TargetsMap targets_;
   /*! \brief params */

--- a/src/relay/ir/dataflow_matcher.cc
+++ b/src/relay/ir/dataflow_matcher.cc
@@ -615,7 +615,7 @@ class PatternGrouper {
     group.root_node = expr;
     group.matched_nodes = node_map;
 
-    std::unordered_map<Expr, Var, ObjectPtrHash, ObjectPtrEqual> inputs;
+    std::unordered_map<Expr, Var, RelayNodeHash, RelayNodeEqual> inputs;
     Array<Var> params;
     for (auto node : pattern_graph_.topological_order_) {
       if (node->inputs_.size() == 0) {

--- a/src/relay/ir/dataflow_matcher.cc
+++ b/src/relay/ir/dataflow_matcher.cc
@@ -589,7 +589,7 @@ class PatternGrouper {
       return out;
     };
     std::string name_;
-    const std::unordered_map<Expr, Var, ObjectPtrHash, ObjectPtrEqual> inputs_;
+    const std::unordered_map<Expr, Var, RelayNodeHash, RelayNodeEqual> inputs_;
   };
 
   /*! \brief Create a group based on a matched expression */

--- a/src/relay/ir/dataflow_matcher.cc
+++ b/src/relay/ir/dataflow_matcher.cc
@@ -535,9 +535,9 @@ class PatternGrouper {
   class MatchExtractor : public ExprMutator {
    public:
     explicit MatchExtractor(
-        const std::unordered_map<Expr, Var, ObjectPtrHash, ObjectPtrEqual>& inputs)
+        const std::unordered_map<Expr, Var, RelayNodeHash, RelayNodeEqual>& inputs)
         : inputs_(inputs) {}
-    const std::unordered_map<Expr, Expr, ObjectPtrHash, ObjectPtrEqual>& GetMemo() {
+    const std::unordered_map<Expr, Expr, RelayNodeHash, RelayNodeEqual>& GetMemo() {
       return this->memo_;
     }
     const std::string& GetName() { return name_; }

--- a/src/relay/ir/expr_functor.cc
+++ b/src/relay/ir/expr_functor.cc
@@ -258,7 +258,20 @@ Expr ExprMutator::VisitExpr_(const FunctionNode* op) {
 }
 
 Expr ExprMutator::VisitExpr_(const CallNode* call_node) {
-  auto new_op = this->Mutate(call_node->op);const VarNode* op
+  auto new_op = this->Mutate(call_node->op);
+  bool unchanged = call_node->op.same_as(new_op);
+
+  tvm::Array<Type> ty_args;
+  for (auto ty_arg : call_node->type_args) {
+    auto new_ty_arg = this->VisitType(ty_arg);
+    ty_args.push_back(new_ty_arg);
+    unchanged &= new_ty_arg.same_as(ty_arg);
+  }
+
+  tvm::Array<Expr> call_args;
+  for (auto arg : call_node->args) {
+    auto new_arg = this->Mutate(arg);
+    call_args.push_back(new_arg);
     unchanged &= new_arg.same_as(arg);
   }
 

--- a/src/relay/transforms/convert_layout.cc
+++ b/src/relay/transforms/convert_layout.cc
@@ -65,7 +65,7 @@ class ConvertTransformMemorizerNode : public TransformMemorizerNode {
 /*!
  * \brief Container that provides the transformation function for convert layout.
  */
-class ConvertTransformMemorizer : public TransformMemorizer {
+class ConvertTransformMemorizer : public TransformMemorizer { // also a potential problem
  public:
   ConvertTransformMemorizer() {}
   explicit ConvertTransformMemorizer(ObjectPtr<Object> n) : TransformMemorizer(n) {}

--- a/src/relay/transforms/convert_layout.cc
+++ b/src/relay/transforms/convert_layout.cc
@@ -74,6 +74,7 @@ class ConvertTransformMemorizer : public TransformMemorizer { // also a potentia
     return static_cast<ConvertTransformMemorizerNode*>(get_mutable());
   }
 
+
   /*!
    * \brief Defines the call transformation for ConvertLayout pass. The new layouts should be the
    * desired layout as specified by the user.

--- a/src/relay/transforms/dead_code.cc
+++ b/src/relay/transforms/dead_code.cc
@@ -110,12 +110,12 @@ class CalcDep : protected MixedModeVisitor {
   using MixedModeVisitor::VisitExpr_;
 
   void VisitLeaf(const Expr& e) final {
-    visit_counter_[e.get()]++;
+    visit_counter_[e]++;
     // The dce code separate variable into three parts:
     // used 0 times (remove)
     // used 1 times (inline)
     // used 2 times (dont do anything).
-    if (visit_counter_[e.get()] <= 2) {
+    if (visit_counter_[e] <= 2) {
       using TParent = ExprFunctor<void(const Expr&)>;
       TParent::VisitExpr(e);
     }

--- a/src/relay/transforms/fold_scale_axis.cc
+++ b/src/relay/transforms/fold_scale_axis.cc
@@ -616,8 +616,6 @@ class BackwardPrep : private ExprVisitor {
     return std::move(message_);
   }
 
-  // WHAT IS GOING ON HERE?????? 
-
  private:
   // The message on each node.
   std::unordered_map<const Expr, Message, RelayNodeHash, RelayNodeEqual> message_;
@@ -654,7 +652,7 @@ class BackwardTransformerNode : public Object, private ExprMutator {
  public:
   // Run forward transform.
   Expr Fold(Expr expr) {
-    message_ = BackwardPrep().Prepare(GetRef<Expr>(expr));
+    message_ = BackwardPrep().Prepare(expr);
     return this->Mutate(expr);
   }
   /*!
@@ -695,7 +693,7 @@ class BackwardTransformerNode : public Object, private ExprMutator {
    * \return The message containing the expected axes and whether positive scale is required.
    */
   Message GetMessage(const Expr& expr) const {
-    auto it = message_.find(expr.get());
+    auto it = message_.find(expr);
     if (it != message_.end()) return it->second;
     return NullValue<Message>();
   }
@@ -708,7 +706,7 @@ class BackwardTransformerNode : public Object, private ExprMutator {
 
  private:
   // Valid axes on each node.
-  std::unordered_map<const Object*, Message> message_;
+  std::unordered_map<const Expr, Message, RelayNodeHash, RelayNodeEqual> message_;
   // Override mutation of call.
   Expr VisitExpr_(const CallNode* call_node) final {
     return Transform(call_node, NullValue<Message>(), NullValue<Expr>());

--- a/src/relay/transforms/fold_scale_axis.cc
+++ b/src/relay/transforms/fold_scale_axis.cc
@@ -610,24 +610,26 @@ using FBackwardTransform =
 class BackwardPrep : private ExprVisitor {
  public:
   // The message on each node.
-  std::unordered_map<const Object*, Message> Prepare(const Expr& body) {
+  std::unordered_map<const Expr, Message, RelayNodeHash, RelayNodeEqual> Prepare(const Expr& body) {
     ref_counter_ = GetExprRefCount(body);
     this->VisitExpr(body);
     return std::move(message_);
   }
 
+  // WHAT IS GOING ON HERE?????? 
+
  private:
   // The message on each node.
-  std::unordered_map<const Object*, Message> message_;
+  std::unordered_map<const Expr, Message, RelayNodeHash, RelayNodeEqual> message_;
   // reference counter of an internal expr
-  std::unordered_map<const Object*, size_t> ref_counter_;
+  std::unordered_map<const Expr, size_t, RelayNodeHash, RelayNodeEqual> ref_counter_;
   // Visit the expression.
   void VisitExpr_(const CallNode* call) {
     ExprVisitor::VisitExpr_(call);
     static const auto& fprep = Op::GetAttrMap<FBackwardPrep>("FScaleAxisBackwardPrep");
     auto f = fprep.get(call->op, nullptr);
     if (f == nullptr) return;
-    auto rit = ref_counter_.find(call);
+    auto rit = ref_counter_.find(GetRef<Expr>(call));
     CHECK(rit != ref_counter_.end());
     // We only allow propagation of scale backward
     // if the expression is only referred by a single parent.

--- a/src/relay/transforms/fold_scale_axis.cc
+++ b/src/relay/transforms/fold_scale_axis.cc
@@ -636,7 +636,7 @@ class BackwardPrep : private ExprVisitor {
     if (rit->second != 1) return;
     Array<Message> in_messages;
     for (Expr arg : call->args) {
-      auto it = message_.find(arg.get());
+      auto it = message_.find(arg);
       if (it != message_.end()) {
         in_messages.push_back(it->second);
       } else {
@@ -645,7 +645,7 @@ class BackwardPrep : private ExprVisitor {
     }
     Message out_message = f(GetRef<Call>(call), in_messages);
     if (out_message.defined()) {
-      message_[call] = out_message;
+      message_[GetRef<Expr>(call)] = out_message;
     }
   }
 };
@@ -654,7 +654,7 @@ class BackwardTransformerNode : public Object, private ExprMutator {
  public:
   // Run forward transform.
   Expr Fold(Expr expr) {
-    message_ = BackwardPrep().Prepare(expr);
+    message_ = BackwardPrep().Prepare(GetRef<Expr>(expr));
     return this->Mutate(expr);
   }
   /*!

--- a/src/relay/transforms/forward_rewrite.cc
+++ b/src/relay/transforms/forward_rewrite.cc
@@ -88,7 +88,7 @@ class ForwardRewriter : private MixedModeMutator {
   Expr GetTempExpr(const Expr& expr, const Expr& post) {
     if (fmulti_ref_trigger_ != nullptr) {
       Expr ret = post;
-      auto it = ref_counter_.find(expr.get());
+      auto it = ref_counter_.find(expr);
       CHECK(it != ref_counter_.end());
       if (it->second > 1) {
         ret = fmulti_ref_trigger_(ret);

--- a/src/relay/transforms/forward_rewrite.cc
+++ b/src/relay/transforms/forward_rewrite.cc
@@ -80,7 +80,7 @@ class ForwardRewriter : private MixedModeMutator {
   // The multiple reference trigger
   std::function<Expr(const Expr&)> fmulti_ref_trigger_{nullptr};
   // Internal ref counter
-  std::unordered_map<const Object*, size_t> ref_counter_;
+  std::unordered_map<const Expr, size_t, RelayNodeHash, RelayNodeEqual> ref_counter_;
   // internal realizer
   TempRealizer realizer_;
 

--- a/src/relay/transforms/transform_layout.h
+++ b/src/relay/transforms/transform_layout.h
@@ -89,12 +89,13 @@ class TransformMemorizer : public ObjectRef {
     if (src_layout.Equals(dst_layout)) {
       return raw;
     }
-
+    std::cout << "raw" << raw << std::endl;
+    std::cout << "raw.get" << raw.get() << std::endl;
     std::tuple<const Object*, std::string, std::string> key =
         std::make_tuple<>(raw.get(), src_layout.name(), dst_layout.name());
     auto& memo = operator->()->memo;
 
-    auto iter = memo.find(key);
+    auto iter = memo.find(key); // this is looking stuff up via pointer equality which is a yikes!!!
     if (iter != memo.end()) {
       return iter->second;
     } else {
@@ -212,7 +213,7 @@ class LayoutAlternatedExpr : public ObjectRef {
  * \param new_args The new arguments (some of them could be TempExpr).
  * \param ctx  Optional context information about ref_call.
  * \tparam TransformMemorizerT The derived TransformMemorizer type.
- * \return The rewriten result call, can also return nullptr,
+ * \return The rewritten result call, can also return nullptr,
  *         which indicate the rewriter should use the default fallback
  *         rule that realizes all its input and compose the call.
  *
@@ -288,7 +289,7 @@ Expr LayoutRewriter(const Call& ref_call, const Array<Expr>& new_args, const Obj
     return Expr(nullptr);
   }
   CHECK_EQ(old_in.size(), new_in.size());
-
+  // reading stuff here!
   // if new_in == 'undef':  new_in = old_in
   for (size_t i = 0; i < new_in.size(); ++i) {
     if (!new_in[i].defined()) {
@@ -297,7 +298,7 @@ Expr LayoutRewriter(const Call& ref_call, const Array<Expr>& new_args, const Obj
   }
 
   // new_op = alter(op)
-  Call new_call = memorizer.CallWithNewLayouts(ref_call, normal_new_args);
+  Call new_call = memorizer.CallWithNewLayouts(ref_call, normal_new_args); // maybe the issue is happening here
 
   // new_in2, new_out = op.infer(new_in)
   if (new_call->op->IsInstance<OpNode>()) {

--- a/tests/python/relay/test_pass_alter_op_layout.py
+++ b/tests/python/relay/test_pass_alter_op_layout.py
@@ -309,9 +309,11 @@ def test_alter_layout_resnet():
 
     with TempOpAttr("nn.conv2d", "FTVMAlterOpLayout", alter_conv2d):
         a = before()
+        print("before: \n", a)
         a = run_opt_pass(a, transform.AlterOpLayout())
+        print("after: \n", a)
         b = run_opt_pass(expected(), transform.InferType())
-
+        print("expected: \n", b)
     assert tvm.ir.structural_equal(a, b), "Actual = \n" + str(a)
 
 

--- a/tests/python/relay/test_pass_convert_op_layout.py
+++ b/tests/python/relay/test_pass_convert_op_layout.py
@@ -396,9 +396,11 @@ def test_resnet_convert_layout():
         return relay.Function(analysis.free_vars(y), y)
 
     a = before()
+    print("before: \n", a)
     a = run_opt_pass(a, transform.ConvertLayout({"nn.conv2d": ["NCHW", "default"]}))
     b = run_opt_pass(expected(), transform.InferType())
-
+    print("expected: \n", b)
+    print("actual: \n", a)
     assert tvm.ir.structural_equal(a, b), "Actual = \n" + str(a)
 
 


### PR DESCRIPTION
Introduces RelayNodeHash and RelayNodeEqual to allow variable nodes to be compared by vid and not through pointer equality. 

This fixes many failing passes, including alter_op_layout, pass annotation, some of auto_quantize, combine_parallel_batch_matmul, combine_parallel_conv2d, combine_parallel_dense, convert_op_layout, dynamic_to_static, eliminate_common_subexpr, fold_constant, fuse_ops, inline, lambda_lift, pass_manager, merge_composite, partition_graph, some of to_normal_form, some of cps, and to_graph_normal_form